### PR TITLE
[feat #163] extract react-query usage into custom hooks

### DIFF
--- a/apps/arkmarket/src/app/collection/[collectionAddress]/components/collection-activity-data.tsx
+++ b/apps/arkmarket/src/app/collection/[collectionAddress]/components/collection-activity-data.tsx
@@ -1,14 +1,12 @@
 "use client";
 
 import { useMemo } from "react";
-import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
 
-import type { CollectionActivityApiResponse } from "~/lib/getCollectionActivity";
 import type { ActivityType } from "~/types";
 import useInfiniteWindowScroll from "~/hooks/useInfiniteWindowScroll";
-import { getCollectionActivity } from "~/lib/getCollectionActivity";
 import DesktopCollectionActivityData from "./desktop-collection-activity";
 import MobileCollectionActivity from "./mobile-collection-activity";
+import useCollectionActivity from "~/hooks/useCollectionActivity";
 
 interface CollectionProps {
   collectionAddress: string;
@@ -25,20 +23,7 @@ export default function CollectionActivityData({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useInfiniteQuery({
-    queryKey: ["collectionActivity", collectionAddress, ...filters],
-    refetchInterval: 10_000,
-    placeholderData: keepPreviousData,
-    getNextPageParam: (lastPage: CollectionActivityApiResponse) =>
-      lastPage.next_page,
-    initialPageParam: undefined,
-    queryFn: ({ pageParam }) =>
-      getCollectionActivity({
-        page: pageParam,
-        collectionAddress,
-        activityFilters: filters,
-      }),
-  });
+  } = useCollectionActivity({ collectionAddress, filters })
   useInfiniteWindowScroll({
     fetchNextPage,
     hasNextPage,

--- a/apps/arkmarket/src/app/collection/[collectionAddress]/components/collection-header.tsx
+++ b/apps/arkmarket/src/app/collection/[collectionAddress]/components/collection-header.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
 
 import { cn, focusableStyles } from "@ark-market/ui";
 import {
@@ -20,8 +19,9 @@ import {
 import type { Collection } from "~/types";
 import CopyButton from "~/components/copy-button";
 import ExternalLink from "~/components/external-link";
-import getCollection from "~/lib/getCollection";
 import CollectionHeaderStats from "./collection-header-stats";
+
+import useCollection from "~/hooks/useCollection";
 
 interface CollectionHeaderProps {
   collectionAddress: string;
@@ -34,12 +34,7 @@ export default function CollectionHeader({
 }: CollectionHeaderProps) {
   const [collapsibleOpen, setCollapsibleOpen] = useState(false);
 
-  const { data } = useQuery({
-    queryKey: ["collection", collectionAddress],
-    queryFn: () => getCollection({ collectionAddress }),
-    initialData: collection,
-    refetchInterval: 15_000,
-  });
+  const { data } = useCollection({ address:collectionAddress })
 
   if (!data) {
     return null;

--- a/apps/arkmarket/src/app/collection/[collectionAddress]/components/collection-items-data.tsx
+++ b/apps/arkmarket/src/app/collection/[collectionAddress]/components/collection-items-data.tsx
@@ -1,19 +1,17 @@
 "use client";
 
 import { useMemo } from "react";
-import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 
 import type { ViewType } from "../../../../components/view-type-toggle-group";
 import type {
   CollectionSortBy,
   CollectionSortDirection,
-  CollectionTokensApiResponse,
 } from "~/lib/getCollectionTokens";
 import type { CollectionToken, Filters } from "~/types";
 import useInfiniteWindowScroll from "~/hooks/useInfiniteWindowScroll";
-import { getCollectionTokens } from "~/lib/getCollectionTokens";
 import CollectionItemsDataGridView from "./collection-items-data-grid-view";
 import CollectionItemsDataListView from "./collection-items-data-list-view";
+import useCollectionTokens from "~/hooks/useCollectionTokens";
 
 interface CollectionItemsDataProps {
   collectionAddress: string;
@@ -37,29 +35,7 @@ export default function CollectionItemsData({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useSuspenseInfiniteQuery({
-    queryKey: [
-      "collectionTokens",
-      sortDirection,
-      sortBy,
-      collectionAddress,
-      filters,
-      buyNow,
-    ],
-    refetchInterval: 10_000,
-    getNextPageParam: (lastPage: CollectionTokensApiResponse) =>
-      lastPage.next_page,
-    initialPageParam: undefined as number | undefined,
-    queryFn: ({ pageParam }) =>
-      getCollectionTokens({
-        collectionAddress,
-        page: pageParam,
-        sortDirection,
-        sortBy,
-        filters,
-        buyNow,
-      }),
-  });
+  } = useCollectionTokens({ collectionAddress, filters, sortBy, sortDirection, buyNow })
 
   useInfiniteWindowScroll({
     fetchNextPage,

--- a/apps/arkmarket/src/app/collection/[collectionAddress]/components/collection-items-filters-dialog.tsx
+++ b/apps/arkmarket/src/app/collection/[collectionAddress]/components/collection-items-filters-dialog.tsx
@@ -8,6 +8,8 @@ import type { Filters } from "~/types";
 import getCollectionTraits from "~/lib/getCollectionTraits";
 import CollectionItemsFiltersTrait from "./collection-items-filters-trait";
 
+import useCollectionTraits from "~/hooks/useCollectionTraits";
+
 interface CollectionItemsFiltersDialogProps {
   collectionAddress: string;
   filters: Filters;
@@ -25,10 +27,7 @@ export default function CollectionItemsFiltersDialog({
   open,
   setOpen,
 }: CollectionItemsFiltersDialogProps) {
-  const { data } = useQuery({
-    queryKey: ["collectionTraits", collectionAddress],
-    queryFn: () => getCollectionTraits({ collectionAddress }),
-  });
+  const { data } = useCollectionTraits({ address:collectionAddress })
 
   const handleTraitChange = async (name: string, value: string) => {
     const values = filters.traits[name] ?? [];

--- a/apps/arkmarket/src/app/collection/[collectionAddress]/components/collection-items-filters-dialog.tsx
+++ b/apps/arkmarket/src/app/collection/[collectionAddress]/components/collection-items-filters-dialog.tsx
@@ -1,11 +1,9 @@
-import { useQuery } from "@tanstack/react-query";
 
 import { Button } from "@ark-market/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@ark-market/ui/dialog";
 import { ScrollArea } from "@ark-market/ui/scroll-area";
 
 import type { Filters } from "~/types";
-import getCollectionTraits from "~/lib/getCollectionTraits";
 import CollectionItemsFiltersTrait from "./collection-items-filters-trait";
 
 import useCollectionTraits from "~/hooks/useCollectionTraits";

--- a/apps/arkmarket/src/app/collection/[collectionAddress]/components/collection-items-filters-panel.tsx
+++ b/apps/arkmarket/src/app/collection/[collectionAddress]/components/collection-items-filters-panel.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
-import { useSuspenseQuery } from "@tanstack/react-query";
 
 import { SearchInput } from "@ark-market/ui/search-input";
 
 import type { Filters } from "~/types";
-import getCollectionTraits from "~/lib/getCollectionTraits";
 import CollectionItemsFiltersContent from "./collection-items-filters-content";
 import CollectionItemsFiltersTrait from "./collection-items-filters-trait";
+
+import useCollectionTraitsSuspense from "~/hooks/useCollectionTraitsSuspense";
 
 interface CollectionItemsFiltersPanelProps {
   collectionAddress: string;
@@ -25,10 +25,7 @@ export default function CollectionItemsFiltersPanel({
   buyNow,
   setBuyNow,
 }: CollectionItemsFiltersPanelProps) {
-  const { data } = useSuspenseQuery({
-    queryKey: ["collectionTraits", collectionAddress],
-    queryFn: () => getCollectionTraits({ collectionAddress }),
-  });
+  const { data } = useCollectionTraitsSuspense({ collectionAddress })
   const [searchQuery, setSearchQuery] = useState("");
 
   const handleTraitChange = async (name: string, value: string) => {

--- a/apps/arkmarket/src/app/token/[contractAddress]/[tokenId]/components/token-actions-create-listing.tsx
+++ b/apps/arkmarket/src/app/token/[contractAddress]/[tokenId]/components/token-actions-create-listing.tsx
@@ -5,7 +5,6 @@ import { useEffect, useState } from "react";
 import { useCreateAuction, useCreateListing } from "@ark-project/react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useAccount } from "@starknet-react/core";
-import { useQuery } from "@tanstack/react-query";
 import moment from "moment";
 import { useForm } from "react-hook-form";
 import { formatEther, parseEther } from "viem";
@@ -46,10 +45,11 @@ import { env } from "~/env";
 import usePrices from "~/hooks/usePrices";
 import useTokenMarketdata from "~/hooks/useTokenMarketData";
 import formatAmount from "~/lib/formatAmount";
-import getCollection from "~/lib/getCollection";
 import ToastExecutedTransactionContent from "./toast-executed-transaction-content";
 import ToastRejectedTransactionContent from "./toast-rejected-transaction-content";
 import TokenActionsTokenOverview from "./token-actions-token-overview";
+
+import useCollection from "~/hooks/useCollection";
 
 interface TokenActionsCreateListingProps {
   token: Token | WalletToken;
@@ -69,14 +69,7 @@ export function TokenActionsCreateListing({
   });
   const [isOpen, setIsOpen] = useState(false);
   const [isAuction, setIsAuction] = useState(false);
-  const { data: collection } = useQuery({
-    queryKey: ["collection", token.collection_address],
-    queryFn: () =>
-      getCollection({
-        collectionAddress: token.collection_address,
-      }),
-    refetchInterval: 5_000,
-  });
+  const { data: collection } = useCollection({ address:token.collection_address })
   const { createListing, status } = useCreateListing();
   const { create: createAuction, status: auctionStatus } = useCreateAuction();
   const { toast } = useToast();

--- a/apps/arkmarket/src/app/token/[contractAddress]/[tokenId]/components/token-actions.tsx
+++ b/apps/arkmarket/src/app/token/[contractAddress]/[tokenId]/components/token-actions.tsx
@@ -1,17 +1,16 @@
 "use client";
 
 import { useAccount } from "@starknet-react/core";
-import { useQuery } from "@tanstack/react-query";
 
 import type { PropsWithClassName } from "@ark-market/ui";
 import { areAddressesEqual, cn } from "@ark-market/ui";
 
 import type { Token, TokenMarketData } from "~/types";
-import getTokenMarketData from "~/lib/getTokenMarketData";
 import TokenActionsButtons from "./token-actions-buttons";
 import TokenActionsEmpty from "./token-actions-empty";
 import TokenActionsHeader from "./token-actions-header";
 import TokenActionsPrice from "./token-actions-price";
+import useTokenMarketdata from "~/hooks/useTokenMarketData";
 
 interface TokenActionsProps {
   token: Token;
@@ -25,16 +24,7 @@ export default function TokenActions({
   className,
 }: TokenActionsProps) {
   const { address } = useAccount();
-  const { data } = useQuery({
-    queryKey: ["tokenMarketData", token.collection_address, token.token_id],
-    queryFn: () =>
-      getTokenMarketData({
-        contractAddress: token.collection_address,
-        tokenId: token.token_id,
-      }),
-    refetchInterval: 5_000,
-    initialData: tokenMarketData,
-  });
+  const { data } = useTokenMarketdata({ collectionAddress: token.collection_address, tokenId: token.token_id, initialData: tokenMarketData })
 
   const isOwner = areAddressesEqual(address, data?.owner);
 

--- a/apps/arkmarket/src/app/token/[contractAddress]/[tokenId]/components/token-activity.tsx
+++ b/apps/arkmarket/src/app/token/[contractAddress]/[tokenId]/components/token-activity.tsx
@@ -6,7 +6,6 @@ import type { PropsWithClassName } from "@ark-market/ui";
 import { cn } from "@ark-market/ui";
 
 import useInfiniteWindowScroll from "~/hooks/useInfiniteWindowScroll";
-import getTokenActivity from "~/lib/getTokenActivity";
 import DesktopTokenActivity from "./desktop-token-activity";
 import MobileTokenActivity from "./mobile-token-activity";
 import useTokenActivity from "~/hooks/useTokenActivity";

--- a/apps/arkmarket/src/app/token/[contractAddress]/[tokenId]/components/token-activity.tsx
+++ b/apps/arkmarket/src/app/token/[contractAddress]/[tokenId]/components/token-activity.tsx
@@ -1,16 +1,15 @@
 "use client";
 
 import { useMemo, useRef } from "react";
-import { useInfiniteQuery } from "@tanstack/react-query";
 
 import type { PropsWithClassName } from "@ark-market/ui";
 import { cn } from "@ark-market/ui";
 
-import type { TokenActivityApiResponse } from "~/lib/getTokenActivity";
 import useInfiniteWindowScroll from "~/hooks/useInfiniteWindowScroll";
 import getTokenActivity from "~/lib/getTokenActivity";
 import DesktopTokenActivity from "./desktop-token-activity";
 import MobileTokenActivity from "./mobile-token-activity";
+import useTokenActivity from "~/hooks/useTokenActivity";
 
 interface TokenActivityProps {
   contractAddress: string;
@@ -28,16 +27,7 @@ export default function TokenActivity({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useInfiniteQuery({
-    queryKey: ["tokenActivity", contractAddress, tokenId],
-    refetchInterval: 10_000,
-    // getNextPageParam: (lastPage) => lastPage.next_page,
-    getNextPageParam: (lastPage?: TokenActivityApiResponse) =>
-      lastPage?.next_page,
-    initialPageParam: undefined,
-    queryFn: ({ pageParam }) =>
-      getTokenActivity({ contractAddress, tokenId, page: pageParam }),
-  });
+  } = useTokenActivity({ contractAddress, tokenId })
 
   const totalCount = infiniteData?.pages[0]?.count ?? 0;
   const tokenActivity = useMemo(

--- a/apps/arkmarket/src/app/token/[contractAddress]/[tokenId]/components/token-offers.tsx
+++ b/apps/arkmarket/src/app/token/[contractAddress]/[tokenId]/components/token-offers.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
 import { useMediaQuery } from "usehooks-ts";
 
 import type { PropsWithClassName } from "@ark-market/ui";
@@ -14,11 +13,10 @@ import {
 } from "@ark-market/ui/collapsible";
 import { ChevronDown, ChevronUp, NoOffer } from "@ark-market/ui/icons";
 
-import type { TokenOffersApiResponse } from "~/lib/getTokenOffers";
 import type { Token, TokenMarketData } from "~/types";
-import { getTokenOffers } from "~/lib/getTokenOffers";
 import TokenOfferList from "./token-offers-list";
 import TokenOffersTable from "./token-offers-table";
+import useTokenOffers from "~/hooks/useTokenOffers";
 
 interface TokenOffersProps {
   token: Token;
@@ -38,19 +36,9 @@ export default function TokenOffers({
     isFetching,
     hasNextPage,
     fetchNextPage,
-  } = useInfiniteQuery({
-    queryKey: ["tokenOffers", token.collection_address, token.token_id],
-    refetchInterval: 10_000,
-    getNextPageParam: (lastPage: TokenOffersApiResponse) => lastPage.next_page,
-    placeholderData: keepPreviousData,
-    initialPageParam: undefined,
-    queryFn: ({ pageParam }) =>
-      getTokenOffers({
-        contractAddress: token.collection_address,
-        tokenId: token.token_id,
-        page: pageParam,
-      }),
-  });
+  } = useTokenOffers({ token })
+   
+    
   const offersCount = infiniteData?.pages[0]?.count ?? 0;
   const tokenOffers = useMemo(
     () => infiniteData?.pages.flatMap((page) => page.data) ?? [],

--- a/apps/arkmarket/src/app/wallet/[walletAddress]/components/portfolio-activity-data.tsx
+++ b/apps/arkmarket/src/app/wallet/[walletAddress]/components/portfolio-activity-data.tsx
@@ -1,14 +1,12 @@
 "use client";
 
 import { useMemo } from "react";
-import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
 
-import type { PortfolioActivityApiResponse } from "~/lib/getPortfolioActivity";
 import type { ActivityType } from "~/types";
 import useInfiniteWindowScroll from "~/hooks/useInfiniteWindowScroll";
-import { getPortfolioActivity } from "~/lib/getPortfolioActivity";
 import DesktopPortfolioActivity from "./desktop-portfolio-activity";
 import MobilePortfolioActivity from "./mobile-portfolio-activity";
+import useWalletActivity from "~/hooks/useWalletActivity";
 
 interface PortfolioActivityDataProps {
   walletAddress: string;
@@ -24,20 +22,7 @@ export default function PortfolioActivityData({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useInfiniteQuery({
-    queryKey: ["walletActivity", walletAddress, ...activityFilters],
-    refetchInterval: 10_000,
-    placeholderData: keepPreviousData,
-    getNextPageParam: (lastPage: PortfolioActivityApiResponse) =>
-      lastPage.next_page,
-    initialPageParam: undefined,
-    queryFn: ({ pageParam }) =>
-      getPortfolioActivity({
-        page: pageParam,
-        walletAddress,
-        activityFilters,
-      }),
-  });
+  } = useWalletActivity({ activityFilters, walletAddress })
 
   useInfiniteWindowScroll({
     fetchNextPage,

--- a/apps/arkmarket/src/app/wallet/[walletAddress]/components/portfolio-items-filters-content.tsx
+++ b/apps/arkmarket/src/app/wallet/[walletAddress]/components/portfolio-items-filters-content.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useMemo } from "react";
-import { useInfiniteQuery } from "@tanstack/react-query";
 import { useQueryState } from "nuqs";
 import { validateAndParseAddress } from "starknet";
 
@@ -16,13 +15,12 @@ import {
 import { VerifiedIcon } from "@ark-market/ui/icons";
 import { Input } from "@ark-market/ui/input";
 
-import type { WalletCollectionsApiResponse } from "../queries/getWalletData";
 import Media from "~/components/media";
-import { getWalletCollections } from "../queries/getWalletData";
 import {
   walletCollectionFilterKey,
   walletCollectionFilterParser,
 } from "../search-params";
+import useWalletCollections from "~/hooks/useWalletCollections";
 
 interface PortfolioItemsFiltersContentProps {
   walletAddress: string;
@@ -46,22 +44,7 @@ export default function PortfolioItemsFiltersContent({
     // fetchNextPage,
     // hasNextPage,
     // isFetchingNextPage,
-  } = useInfiniteQuery({
-    queryKey: ["walletCollections", walletAddress],
-    refetchInterval: 10_000,
-    getNextPageParam: (lastPage: WalletCollectionsApiResponse) =>
-      lastPage.next_page,
-    // initialData: {
-    //   pages: [walletCollectionsInitialData],
-    //   pageParams: [],
-    // },
-    initialPageParam: undefined,
-    queryFn: ({ pageParam }) =>
-      getWalletCollections({
-        page: pageParam,
-        walletAddress,
-      }),
-  });
+  } = useWalletCollections({ walletAddress })
 
   const isCollectionSelected = useCallback(
     (collectionAddress: string): boolean => {

--- a/apps/arkmarket/src/app/wallet/[walletAddress]/components/portfolio-offers-data.tsx
+++ b/apps/arkmarket/src/app/wallet/[walletAddress]/components/portfolio-offers-data.tsx
@@ -1,16 +1,14 @@
 "use client";
 
 import { useMemo } from "react";
-import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
 
 import type {
-  PortfolioOffersApiResponse,
   PortfolioOffersTypeValues,
 } from "~/lib/getPortfolioOffers";
 import useInfiniteWindowScroll from "~/hooks/useInfiniteWindowScroll";
-import { getPortfolioOffers } from "~/lib/getPortfolioOffers";
 import DesktopPortfolioOffers from "./desktop-portfolio-offers";
 import MobilePortfolioOffers from "./mobile-portfolio-offers";
+import useWalletOffers from "~/hooks/useWalletOffers";
 
 interface PortfolioActivityDataProps {
   walletAddress: string;
@@ -28,20 +26,7 @@ export default function PortfolioOffersData({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useInfiniteQuery({
-    queryKey: ["walletOffers", walletAddress, offerType],
-    refetchInterval: 10_000,
-    placeholderData: keepPreviousData,
-    getNextPageParam: (lastPage: PortfolioOffersApiResponse) =>
-      lastPage.next_page,
-    initialPageParam: undefined,
-    queryFn: ({ pageParam }) =>
-      getPortfolioOffers({
-        page: pageParam,
-        walletAddress,
-        offerType,
-      }),
-  });
+  } = useWalletOffers({ offerType, walletAddress })
 
   useInfiniteWindowScroll({
     fetchNextPage,

--- a/apps/arkmarket/src/app/wallet/[walletAddress]/components/portfolio.tsx
+++ b/apps/arkmarket/src/app/wallet/[walletAddress]/components/portfolio.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState } from "react";
 import { useAccount } from "@starknet-react/core";
-import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
 import { parseAsArrayOf, parseAsStringLiteral, useQueryState } from "nuqs";
 import { validateAndParseAddress } from "starknet";
 
@@ -12,7 +11,6 @@ import CollectionActivityFiltersModal from "~/app/collection/[collectionAddress]
 import CollectionActivityFiltersToggle from "~/app/collection/[collectionAddress]/components/collection-activity-filters-toggle";
 import { portfolioOffersTypeValues } from "~/lib/getPortfolioOffers";
 import { activityTypes } from "~/types";
-import { getWalletTokens } from "../queries/getWalletData";
 import {
   walletCollectionFilterKey,
   walletCollectionFilterParser,
@@ -27,6 +25,7 @@ import PortfolioOffersData from "./portfolio-offers-data";
 import PortfolioOffersFiltersPanel from "./portfolio-offers-filters-panel";
 import PortfolioOffersMobileFilters from "./portfolio-offers-mobile-filters";
 import PortfolioTabs, { portfolioTabsValues } from "./portfolio-tabs";
+import useWalletTokens from "~/hooks/useWalletTokens";
 
 interface PortfolioProps {
   walletAddress: string;
@@ -79,25 +78,7 @@ export default function Portfolio({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useInfiniteQuery({
-    queryKey: ["walletTokens", collectionFilter, walletAddress],
-    refetchInterval: 10_000,
-    placeholderData: keepPreviousData,
-    getNextPageParam: (lastPage: WalletTokensApiResponse) => lastPage.next_page,
-    // initialData: isSSR
-    //   ? {
-    //       pages: [walletTokensInitialData],
-    //       pageParams: [],
-    //     }
-    //   : undefined,
-    initialPageParam: undefined,
-    queryFn: ({ pageParam }) =>
-      getWalletTokens({
-        page: pageParam,
-        walletAddress,
-        collectionAddress: collectionFilter,
-      }),
-  });
+  } = useWalletTokens({ collectionFilter, walletAddress })
   const portoflioItemsCount = infiniteData?.pages[0]?.token_count ?? 0;
 
   const walletTokens = useMemo(

--- a/apps/arkmarket/src/app/wallet/[walletAddress]/components/portfolio.tsx
+++ b/apps/arkmarket/src/app/wallet/[walletAddress]/components/portfolio.tsx
@@ -5,7 +5,6 @@ import { useAccount } from "@starknet-react/core";
 import { parseAsArrayOf, parseAsStringLiteral, useQueryState } from "nuqs";
 import { validateAndParseAddress } from "starknet";
 
-import type { WalletTokensApiResponse } from "../queries/getWalletData";
 import type { ViewType } from "~/components/view-type-toggle-group";
 import CollectionActivityFiltersModal from "~/app/collection/[collectionAddress]/components/collection-activity-filters-modal";
 import CollectionActivityFiltersToggle from "~/app/collection/[collectionAddress]/components/collection-activity-filters-toggle";

--- a/apps/arkmarket/src/components/global-search.tsx
+++ b/apps/arkmarket/src/components/global-search.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { Command as CommandPrimitive } from "cmdk";
 import { useDebounceValue } from "usehooks-ts";
 
@@ -21,10 +20,11 @@ import {
 } from "@ark-market/ui/command";
 import { Ethereum, NoResult, VerifiedIcon } from "@ark-market/ui/icons";
 
-import getCollectionSearch from "~/lib/getCollectionSearch";
 import GlobalSearchSuggestions from "./global-search-suggestions";
 import Media from "./media";
 import ProfilePicture from "./profile-picture";
+
+import useSearchCollection from "~/hooks/useSearchCollection";
 
 interface GlobalSearchCommandsProps {
   inputValue: string;
@@ -37,13 +37,8 @@ function GlobalSearchCommands({
   inputDebouncedValue,
   onClose,
 }: GlobalSearchCommandsProps) {
-  const { data: searchResults } = useQuery({
-    queryKey: ["searchCollection", inputDebouncedValue],
-    refetchInterval: false,
-    placeholderData: keepPreviousData,
-    queryFn: () => getCollectionSearch({ searchQuery: inputDebouncedValue }),
-    enabled: inputDebouncedValue.length >= 3,
-  });
+  const { data: searchResults } = useSearchCollection({ inputDebouncedValue })
+  
   const router = useRouter();
 
   if (

--- a/apps/arkmarket/src/components/mobile-global-search.tsx
+++ b/apps/arkmarket/src/components/mobile-global-search.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useDebounceValue } from "usehooks-ts";
 
 import {
@@ -20,10 +19,11 @@ import {
 import { Ethereum, Meh, Search, VerifiedIcon } from "@ark-market/ui/icons";
 import { SearchInput } from "@ark-market/ui/search-input";
 
-import getCollectionSearch from "~/lib/getCollectionSearch";
 import Media from "./media";
 import MobileGlobalSearchSuggestions from "./mobile-global-search-suggestions";
 import ProfilePicture from "./profile-picture";
+
+import useSearchCollection from "~/hooks/useSearchCollection";
 
 interface MobileGlobalSearchProps {
   inputValue: string;
@@ -36,18 +36,12 @@ function MobileGlobalSearch({
   inputDebouncedValue,
   onClose,
 }: MobileGlobalSearchProps) {
-  const { data: searchResults } = useQuery({
-    queryKey: ["searchCollection", inputDebouncedValue],
-    refetchInterval: false,
-    placeholderData: keepPreviousData,
-    queryFn: () => getCollectionSearch({ searchQuery: inputDebouncedValue }),
-    enabled: inputDebouncedValue.length >= 3,
-  });
+  const { data: searchResults } = useSearchCollection({ inputDebouncedValue })
 
   if (
     searchResults === undefined ||
     inputValue.length < 3 ||
-    inputDebouncedValue.length < 3
+    inputDebouncedValue.length < 3 
   ) {
     return (
       <div>

--- a/apps/arkmarket/src/components/system-status.tsx
+++ b/apps/arkmarket/src/components/system-status.tsx
@@ -26,7 +26,7 @@ const statuses = {
 };
 
 export default function SystemStatus() {
-  const { error, data } = useSystemStatus({})
+  const { error, data } = useSystemStatus()
 
   if (error) {
     return null;

--- a/apps/arkmarket/src/components/system-status.tsx
+++ b/apps/arkmarket/src/components/system-status.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
-
 import { cn } from "@ark-market/ui";
 import {
   Tooltip,
@@ -10,7 +8,7 @@ import {
   TooltipTrigger,
 } from "@ark-market/ui/tooltip";
 
-import getSystemStatus from "~/lib/getSystemStatus";
+import useSystemStatus from "~/hooks/useSystemStatus";
 
 const statuses = {
   ok: {
@@ -28,12 +26,7 @@ const statuses = {
 };
 
 export default function SystemStatus() {
-  const { error, data } = useQuery({
-    queryKey: ["systemStatus"],
-    queryFn: getSystemStatus,
-    refetchInterval: 15_000,
-    initialData: { status: "ok" },
-  });
+  const { error, data } = useSystemStatus({})
 
   if (error) {
     return null;

--- a/apps/arkmarket/src/hooks/useCollectionActivity.tsx
+++ b/apps/arkmarket/src/hooks/useCollectionActivity.tsx
@@ -1,0 +1,31 @@
+import { useInfiniteQuery, keepPreviousData } from "@tanstack/react-query";
+
+import type { ActivityType } from "~/types";
+import type { CollectionActivityApiResponse } from "~/lib/getCollectionActivity";
+
+import { getCollectionActivity } from "~/lib/getCollectionActivity";
+
+interface useCollectionActivityProps {
+  collectionAddress: string;
+  filters: ActivityType[];
+}
+
+export default function useCollectionActivity({ collectionAddress, filters }: useCollectionActivityProps) {
+
+  const result = useInfiniteQuery({
+    queryKey: ["collectionActivity", collectionAddress, ...filters],
+    refetchInterval: 10_000,
+    placeholderData: keepPreviousData,
+    getNextPageParam: (lastPage: CollectionActivityApiResponse) =>
+      lastPage.next_page,
+    initialPageParam: undefined,
+    queryFn: ({ pageParam }) =>
+      getCollectionActivity({
+        page: pageParam,
+        collectionAddress,
+        activityFilters: filters,
+      }),
+  });
+
+  return result;
+}

--- a/apps/arkmarket/src/hooks/useCollectionTokens.tsx
+++ b/apps/arkmarket/src/hooks/useCollectionTokens.tsx
@@ -5,7 +5,6 @@ import type {
   CollectionSortDirection,
   CollectionTokensApiResponse,
 } from "~/lib/getCollectionTokens";
-import type { ViewType } from "~/components/view-type-toggle-group";
 import type { Filters } from "~/types";
 
 import { getCollectionTokens } from "~/lib/getCollectionTokens";
@@ -14,13 +13,13 @@ interface useCollectionTokensProps {
   collectionAddress: string;
   sortBy: CollectionSortBy;
   sortDirection: CollectionSortDirection;
-  viewType: ViewType;
   filters: Filters;
+  buyNow:boolean;
 }
 
 const REFETCH_INTERVAL = 10_000;
 
-export default function useCollectionTokens({ collectionAddress, sortDirection, sortBy, filters }: useCollectionTokensProps) {
+export default function useCollectionTokens({ collectionAddress, sortDirection, sortBy, filters, buyNow }: useCollectionTokensProps) {
   const result = useSuspenseInfiniteQuery({
     queryKey: [
       "collectionTokens",
@@ -28,6 +27,7 @@ export default function useCollectionTokens({ collectionAddress, sortDirection, 
       sortBy,
       collectionAddress,
       filters,
+      buyNow
     ],
     refetchInterval: REFETCH_INTERVAL,
     getNextPageParam: (lastPage: CollectionTokensApiResponse) =>
@@ -40,6 +40,7 @@ export default function useCollectionTokens({ collectionAddress, sortDirection, 
         sortDirection,
         sortBy,
         filters,
+        buyNow
       }),
   });
   return result;

--- a/apps/arkmarket/src/hooks/useCollectionTokens.tsx
+++ b/apps/arkmarket/src/hooks/useCollectionTokens.tsx
@@ -1,0 +1,46 @@
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
+
+import type {
+  CollectionSortBy,
+  CollectionSortDirection,
+  CollectionTokensApiResponse,
+} from "~/lib/getCollectionTokens";
+import type { ViewType } from "~/components/view-type-toggle-group";
+import type { Filters } from "~/types";
+
+import { getCollectionTokens } from "~/lib/getCollectionTokens";
+
+interface useCollectionTokensProps {
+  collectionAddress: string;
+  sortBy: CollectionSortBy;
+  sortDirection: CollectionSortDirection;
+  viewType: ViewType;
+  filters: Filters;
+}
+
+const REFETCH_INTERVAL = 10_000;
+
+export default function useCollectionTokens({ collectionAddress, sortDirection, sortBy, filters }: useCollectionTokensProps) {
+  const result = useSuspenseInfiniteQuery({
+    queryKey: [
+      "collectionTokens",
+      sortDirection,
+      sortBy,
+      collectionAddress,
+      filters,
+    ],
+    refetchInterval: REFETCH_INTERVAL,
+    getNextPageParam: (lastPage: CollectionTokensApiResponse) =>
+      lastPage.next_page,
+    initialPageParam: undefined as number | undefined,
+    queryFn: ({ pageParam }) =>
+      getCollectionTokens({
+        collectionAddress,
+        page: pageParam,
+        sortDirection,
+        sortBy,
+        filters,
+      }),
+  });
+  return result;
+}

--- a/apps/arkmarket/src/hooks/useCollectionTraits.tsx
+++ b/apps/arkmarket/src/hooks/useCollectionTraits.tsx
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+
+import getCollectionTraits from "~/lib/getCollectionTraits"
+
+interface useCollectionTraitsProps {
+  address: string;
+}
+
+export default function useCollectionTraits({ address }: useCollectionTraitsProps) {
+  const result = useQuery({
+    queryKey: ["collectionTraits", address],
+    queryFn: () => 
+      getCollectionTraits({ 
+        collectionAddress:address 
+      }),
+  });
+
+  return result;
+}

--- a/apps/arkmarket/src/hooks/useCollectionTraitsSuspense.tsx
+++ b/apps/arkmarket/src/hooks/useCollectionTraitsSuspense.tsx
@@ -1,0 +1,16 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import getCollectionTraits from "~/lib/getCollectionTraits";
+
+interface useCollectionTraitsSuspenseProps {
+  collectionAddress: string;
+  
+}
+
+export default function useCollectionTraitsSuspense({ collectionAddress }: useCollectionTraitsSuspenseProps) {
+  const result = useSuspenseQuery({
+    queryKey: ["collectionTraits", collectionAddress],
+    queryFn: () => getCollectionTraits({ collectionAddress }),
+  });
+  return result;
+}

--- a/apps/arkmarket/src/hooks/useSearchCollection.tsx
+++ b/apps/arkmarket/src/hooks/useSearchCollection.tsx
@@ -1,0 +1,19 @@
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
+
+import getCollectionSearch from "~/lib/getCollectionSearch"
+
+interface useSearchCollectionProps {
+  inputDebouncedValue: string;
+}
+
+export default function useSearchCollection({ inputDebouncedValue }: useSearchCollectionProps) {
+  const result = useQuery({
+    queryKey: ["searchCollection", inputDebouncedValue],
+    refetchInterval: false,
+    placeholderData: keepPreviousData,
+    queryFn: () => getCollectionSearch({ searchQuery: inputDebouncedValue }),
+    enabled: inputDebouncedValue.length >= 3,
+  });
+
+  return result;
+}

--- a/apps/arkmarket/src/hooks/useSystemStatus.tsx
+++ b/apps/arkmarket/src/hooks/useSystemStatus.tsx
@@ -1,12 +1,11 @@
-import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 
 import getSystemStatus from "~/lib/getSystemStatus"
 
-interface useSystemStatusProps {}
 
 const REFETCH_INTERVAL = 15_000;
 
-export default function useSystemStatus({}: useSystemStatusProps) {
+export default function useSystemStatus() {
   const result = useQuery({
     queryKey: ["systemStatus"],
     queryFn: getSystemStatus,

--- a/apps/arkmarket/src/hooks/useSystemStatus.tsx
+++ b/apps/arkmarket/src/hooks/useSystemStatus.tsx
@@ -1,0 +1,18 @@
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
+
+import getSystemStatus from "~/lib/getSystemStatus"
+
+interface useSystemStatusProps {}
+
+const REFETCH_INTERVAL = 15_000;
+
+export default function useSystemStatus({}: useSystemStatusProps) {
+  const result = useQuery({
+    queryKey: ["systemStatus"],
+    queryFn: getSystemStatus,
+    refetchInterval: REFETCH_INTERVAL,
+    initialData: { status: "ok" },
+  });
+
+  return result;
+}

--- a/apps/arkmarket/src/hooks/useTokenActivity.tsx
+++ b/apps/arkmarket/src/hooks/useTokenActivity.tsx
@@ -1,0 +1,28 @@
+import { useInfiniteQuery, keepPreviousData } from "@tanstack/react-query";
+
+import type { TokenActivityApiResponse } from "~/lib/getTokenActivity";
+
+import getTokenActivity from "~/lib/getTokenActivity";
+
+interface useTokenActivityProps {
+  contractAddress: string;
+  tokenId: string;
+}
+
+const REFETCH_INTERVAL = 10_000;
+
+export default function useTokenActivity({ contractAddress, tokenId }: useTokenActivityProps) {
+
+  const result = useInfiniteQuery({
+    queryKey: ["tokenActivity", contractAddress, tokenId],
+    refetchInterval: REFETCH_INTERVAL,
+    // getNextPageParam: (lastPage) => lastPage.next_page,
+    getNextPageParam: (lastPage?: TokenActivityApiResponse) =>
+      lastPage?.next_page,
+    initialPageParam: undefined,
+    queryFn: ({ pageParam }) =>
+      getTokenActivity({ contractAddress, tokenId, page: pageParam }),
+  });
+
+  return result;
+}

--- a/apps/arkmarket/src/hooks/useTokenActivity.tsx
+++ b/apps/arkmarket/src/hooks/useTokenActivity.tsx
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, keepPreviousData } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 import type { TokenActivityApiResponse } from "~/lib/getTokenActivity";
 

--- a/apps/arkmarket/src/hooks/useTokenOffers.tsx
+++ b/apps/arkmarket/src/hooks/useTokenOffers.tsx
@@ -1,0 +1,31 @@
+import { useInfiniteQuery, keepPreviousData } from "@tanstack/react-query";
+
+import type { Token } from "~/types";
+import type { TokenOffersApiResponse } from "~/lib/getTokenOffers";
+
+import { getTokenOffers } from "~/lib/getTokenOffers";
+
+interface useTokenOffersProps {
+  token: Token,
+}
+
+const REFETCH_INTERVAL = 10_000;
+
+export default function useTokenOffers({ token }: useTokenOffersProps) {
+
+  const result = useInfiniteQuery({
+    queryKey: ["tokenOffers", token.collection_address, token.token_id],
+    refetchInterval: REFETCH_INTERVAL,
+    getNextPageParam: (lastPage: TokenOffersApiResponse) => lastPage.next_page,
+    placeholderData: keepPreviousData,
+    initialPageParam: undefined,
+    queryFn: ({ pageParam }) =>
+      getTokenOffers({
+        contractAddress: token.collection_address,
+        tokenId: token.token_id,
+        page: pageParam,
+      }),
+  });
+
+  return result;
+}

--- a/apps/arkmarket/src/hooks/useWalletActivity.tsx
+++ b/apps/arkmarket/src/hooks/useWalletActivity.tsx
@@ -1,0 +1,33 @@
+import { useInfiniteQuery, keepPreviousData } from "@tanstack/react-query";
+
+import type { ActivityType } from "~/types";
+import type { PortfolioActivityApiResponse } from "~/lib/getPortfolioActivity";
+
+import { getPortfolioActivity } from "~/lib/getPortfolioActivity";
+
+interface useWalletActivityProps {
+  walletAddress: string;
+  activityFilters: ActivityType[];
+}
+
+const REFETCH_INTERVAL = 10_000;
+
+export default function useWalletActivity({ walletAddress, activityFilters }: useWalletActivityProps) {
+
+  const result = useInfiniteQuery({
+    queryKey: ["walletActivity", walletAddress, ...activityFilters],
+    refetchInterval: REFETCH_INTERVAL,
+    placeholderData: keepPreviousData,
+    getNextPageParam: (lastPage: PortfolioActivityApiResponse) =>
+      lastPage.next_page,
+    initialPageParam: undefined,
+    queryFn: ({ pageParam }) =>
+      getPortfolioActivity({
+        page: pageParam,
+        walletAddress,
+        activityFilters,
+      }),
+  });
+
+  return result;
+}

--- a/apps/arkmarket/src/hooks/useWalletCollections.tsx
+++ b/apps/arkmarket/src/hooks/useWalletCollections.tsx
@@ -1,0 +1,33 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import type { WalletCollectionsApiResponse } from "~/app/wallet/[walletAddress]/queries/getWalletData";
+
+import { getWalletCollections } from "~/app/wallet/[walletAddress]/queries/getWalletData";
+
+interface useWalletCollectionsProps {
+  walletAddress: string;
+}
+
+const REFETCH_INTERVAL = 10_000;
+
+export default function useWalletCollections({ walletAddress }: useWalletCollectionsProps) {
+
+  const result = useInfiniteQuery({
+    queryKey: ["walletCollections", walletAddress],
+    refetchInterval: REFETCH_INTERVAL,
+    getNextPageParam: (lastPage: WalletCollectionsApiResponse) =>
+      lastPage.next_page,
+    // initialData: {
+    //   pages: [walletCollectionsInitialData],
+    //   pageParams: [],
+    // },
+    initialPageParam: undefined,
+    queryFn: ({ pageParam }) =>
+      getWalletCollections({
+        page: pageParam,
+        walletAddress,
+      }),
+  });
+
+  return result;
+}

--- a/apps/arkmarket/src/hooks/useWalletOffers.tsx
+++ b/apps/arkmarket/src/hooks/useWalletOffers.tsx
@@ -1,0 +1,36 @@
+import { useInfiniteQuery, keepPreviousData } from "@tanstack/react-query";
+
+import type {
+  PortfolioOffersApiResponse,
+  PortfolioOffersTypeValues,
+} from "~/lib/getPortfolioOffers";
+
+import { getPortfolioOffers } from "~/lib/getPortfolioOffers";
+
+interface useWalletOffersProps {
+  walletAddress: string;
+  offerType: PortfolioOffersTypeValues;
+  isOwner: boolean;
+}
+
+const REFETCH_INTERVAL = 10_000;
+
+export default function useWalletOffers({ walletAddress, offerType }: useWalletOffersProps) {
+
+  const result = useInfiniteQuery({
+    queryKey: ["walletOffers", walletAddress, offerType],
+    refetchInterval: REFETCH_INTERVAL,
+    placeholderData: keepPreviousData,
+    getNextPageParam: (lastPage: PortfolioOffersApiResponse) =>
+      lastPage.next_page,
+    initialPageParam: undefined,
+    queryFn: ({ pageParam }) =>
+      getPortfolioOffers({
+        page: pageParam,
+        walletAddress,
+        offerType,
+      }),
+  });
+
+  return result;
+}

--- a/apps/arkmarket/src/hooks/useWalletOffers.tsx
+++ b/apps/arkmarket/src/hooks/useWalletOffers.tsx
@@ -10,7 +10,6 @@ import { getPortfolioOffers } from "~/lib/getPortfolioOffers";
 interface useWalletOffersProps {
   walletAddress: string;
   offerType: PortfolioOffersTypeValues;
-  isOwner: boolean;
 }
 
 const REFETCH_INTERVAL = 10_000;

--- a/apps/arkmarket/src/hooks/useWalletTokens.tsx
+++ b/apps/arkmarket/src/hooks/useWalletTokens.tsx
@@ -1,0 +1,39 @@
+import { useInfiniteQuery, keepPreviousData } from "@tanstack/react-query";
+
+import type { WalletTokensApiResponse } from "~/app/wallet/[walletAddress]/queries/getWalletData";
+
+import { getWalletTokens } from "~/app/wallet/[walletAddress]/queries/getWalletData";
+
+
+interface useWalletTokensProps {
+  walletAddress: string;
+  collectionFilter: string | null,
+  
+}
+
+const REFETCH_INTERVAL = 10_000;
+
+export default function useWalletTokens({ walletAddress, collectionFilter }: useWalletTokensProps) {
+
+  const result = useInfiniteQuery({
+    queryKey: ["walletTokens", collectionFilter, walletAddress],
+    refetchInterval: REFETCH_INTERVAL,
+    placeholderData: keepPreviousData,
+    getNextPageParam: (lastPage: WalletTokensApiResponse) => lastPage.next_page,
+    // initialData: isSSR
+    //   ? {
+    //       pages: [walletTokensInitialData],
+    //       pageParams: [],
+    //     }
+    //   : undefined,
+    initialPageParam: undefined,
+    queryFn: ({ pageParam }) =>
+      getWalletTokens({
+        page: pageParam,
+        walletAddress,
+        collectionAddress: collectionFilter,
+      }),
+  });
+
+  return result;
+}


### PR DESCRIPTION
#163 Create custom hooks for react-query usage:

### useQuery:
- (was already implemented) useCollection
- useCollectionTraits
- (was already implemented) useTokenMarketData
- useSearchCollection
- useSystemStatus
- (was already implemented) useBalance
- (was already implemented) usePortfolioStats
- (was already implemented) usePrices

### useInfiniteQuery:
- useCollectionActivity
- useTokenActivity
- useTokenOffers
- useWalletActivity
- useWalletCollections
- useWalletOffers
- useWalletTokens

### useSuspenseQuery:
- useCollectionTraits --> renamed to useCollectionTraitsSuspense (there are another hook called useCollectionTraits but with useQuery instead of useSuspenseQuery)

### useSuspenseInfiniteQuery:
- useCollectionTokens