### PR TITLE
chore: remove usage of `NEXT_PUBLIC_ORDERBOOK_API_URL` environment variable

### DIFF
--- a/apps/arkmarket/src/env.ts
+++ b/apps/arkmarket/src/env.ts
@@ -19,7 +19,6 @@ export const env = createEnv({
    * For them to be exposed to the client, prefix them with `NEXT_PUBLIC_`.
    */
   client: {
-    NEXT_PUBLIC_ORDERBOOK_API_URL: z.string().url(),
     NEXT_PUBLIC_MARKETPLACE_API_URL: z.string().url(),
     NEXT_PUBLIC_BROKER_ID: z.string(),
     NEXT_PUBLIC_IPFS_GATEWAY: z.string().url(),
@@ -33,7 +32,6 @@ export const env = createEnv({
    */
   experimental__runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
-    NEXT_PUBLIC_ORDERBOOK_API_URL: process.env.NEXT_PUBLIC_ORDERBOOK_API_URL,
     NEXT_PUBLIC_MARKETPLACE_API_URL:
       process.env.NEXT_PUBLIC_MARKETPLACE_API_URL,
     NEXT_PUBLIC_BROKER_ID: process.env.NEXT_PUBLIC_BROKER_ID,

--- a/apps/arkmarket/src/lib/getSystemStatus.ts
+++ b/apps/arkmarket/src/lib/getSystemStatus.ts
@@ -2,7 +2,7 @@ import type { SystemStatus } from "~/types";
 import { env } from "~/env";
 
 export default async function getSystemStatus() {
-  const response = await fetch(env.NEXT_PUBLIC_ORDERBOOK_API_URL);
+  const response = await fetch(env.NEXT_PUBLIC_MARKETPLACE_API_URL);
   const data = (await response.json()) as SystemStatus;
 
   return data;


### PR DESCRIPTION
This PR removes the dependency on the `NEXT_PUBLIC_ORDERBOOK_API_URL` environment variable within the application. All references to this variable have been updated. 