### PR TITLE
feat(web): add market data enabled flag for collections

### DIFF
--- a/apps/arkmarket/src/app/collection/[collectionAddress]/components/collection-header.tsx
+++ b/apps/arkmarket/src/app/collection/[collectionAddress]/components/collection-header.tsx
@@ -100,9 +100,11 @@ export default function CollectionHeader({
               </div>
             </div>
           </div>
-          <div className="hidden lg:block">
-            <CollectionHeaderStats collection={collection} />
-          </div>
+          {collection.market_data_enabled && (
+            <div className="hidden lg:block">
+              <CollectionHeaderStats collection={collection} />
+            </div>
+          )}
         </div>
         <CollapsibleContent className="data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
           <p className="mb-2 max-w-lg pt-4 text-sm">{collection.description}</p>
@@ -116,9 +118,11 @@ export default function CollectionHeader({
             Creator earnings
             <span className="text-muted-foreground"> 5%</span>
           </p>
-          <div className="block lg:hidden">
-            <CollectionHeaderStats collection={data} />
-          </div>
+          {collection.market_data_enabled && (
+            <div className="block lg:hidden">
+              <CollectionHeaderStats collection={data} />
+            </div>
+          )}
         </CollapsibleContent>
       </Collapsible>
     </div>

--- a/apps/arkmarket/src/app/collection/[collectionAddress]/components/mobile-collection-header.tsx
+++ b/apps/arkmarket/src/app/collection/[collectionAddress]/components/mobile-collection-header.tsx
@@ -85,7 +85,9 @@ export default function MobileCollectionHeader({
                 <Globe className="h-6 w-auto" />
               </ExternalLink>
             </div>
-            <CollectionHeaderStats collection={collection} />
+            {collection.market_data_enabled && (
+              <CollectionHeaderStats collection={collection} />
+            )}
           </div>
         </CollapsibleContent>
       </Collapsible>

--- a/apps/arkmarket/src/types/index.ts
+++ b/apps/arkmarket/src/types/index.ts
@@ -19,6 +19,7 @@ export interface Collection {
   twitter?: string;
   volume_7d_eth: number;
   website?: string;
+  market_data_enabled: boolean;
 }
 
 export type CollectionTrait = Record<string, number>;


### PR DESCRIPTION
## Description
In some cases, collections won't have market data available. 
This PR introduces a new property `market_data_enabled` that indicates whether market data tracking is enabled for a specific collection. This flag helps clients determine whether to display the collection's statistics block in the UI.